### PR TITLE
Add .NET Aspire Dashboard to MVP 1 for runtime observability

### DIFF
--- a/docs/datahub3-implementation-plan.md
+++ b/docs/datahub3-implementation-plan.md
@@ -213,7 +213,7 @@ Run against Energinet's Actor Test or Preprod with real credentials. These tests
 
 | Area | Task | Test approach |
 |------|------|---------------|
-| **Foundation** | .NET solution structure, CI/CD pipeline, Docker Compose (PostgreSQL + TimescaleDB) | Verify container starts, CI runs |
+| **Foundation** | .NET solution structure, CI/CD pipeline, Docker Compose (PostgreSQL + TimescaleDB + Aspire Dashboard). OpenTelemetry for structured logs, traces, metrics | Verify containers start, dashboard shows telemetry, CI runs |
 | **Simulator** | In-process `FakeDataHubClient` loaded with CIM JSON fixtures. Sunshine scenario: BRS-001 → RSM-009 (accepted) → RSM-007 → RSM-012 (31 days). No HTTP — all in-process. | Unit + integration |
 | **Auth** | OAuth2 Auth Manager — token fetch, cache, proactive renewal, 401 retry | Unit: mock token endpoint |
 | **Ingestion** | Queue Poller (Timeseries + MasterData), CIM JSON Parser (RSM-012 + RSM-007), time series storage (`metering_data` hypertable) | Unit: parse fixtures. Integration: parse → store → query roundtrip |
@@ -259,7 +259,7 @@ Golden Master #2: Partial period (mid-month start)
 
 ### Exit criteria
 
-- `docker compose up` starts the database and all services
+- `docker compose up` starts TimescaleDB, Aspire Dashboard, and all services
 - Sunshine scenario works end-to-end: BRS-001 → RSM-009 → RSM-007 → RSM-012 → settlement → golden master match
 - Portfolio: customer + metering point + contract + supply period created correctly
 - State machine: BRS-001 process goes Pending → SentToDataHub → Acknowledged → Completed

--- a/scripts/create-mvp1-backlog.sh
+++ b/scripts/create-mvp1-backlog.sh
@@ -89,7 +89,14 @@ DataHub.Settlement/
 
 ## Docker Compose
 
-TimescaleDB (PostgreSQL 16 + TimescaleDB extension) for both time series and relational data.
+- **TimescaleDB** (PostgreSQL 16 + TimescaleDB extension) for both time series and relational data
+- **.NET Aspire Dashboard** (`mcr.microsoft.com/dotnet/aspire-dashboard`) for runtime monitoring — structured logs, distributed traces, and metrics via OpenTelemetry
+
+## OpenTelemetry
+
+- Add `OpenTelemetry.Extensions.Hosting` + OTLP exporter NuGet packages to the Worker project
+- Configure `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at the Aspire Dashboard container
+- Dashboard accessible at `http://localhost:18888`
 
 ## Dependencies
 
@@ -99,12 +106,14 @@ None — this is the first task.
 
 - [ ] `dotnet build` succeeds
 - [ ] `docker compose up` starts TimescaleDB and it accepts connections
+- [ ] `docker compose up` starts Aspire Dashboard accessible at `http://localhost:18888`
+- [ ] Worker service logs and traces visible in the Aspire Dashboard
 - [ ] All projects reference each other correctly (Domain has no dependencies, Application references Domain, Infrastructure references Application)
 - [ ] `.gitignore` for .NET projects
 
 ## Estimated effort
 
-Small (1 day)
+Small (1.5 days)
 
 ## Reference
 


### PR DESCRIPTION
Adds the Aspire Dashboard (structured logs, traces, metrics) as part of Task 1 Docker Compose setup. No custom UI — OpenTelemetry exports from the .NET worker to the dashboard container.

https://claude.ai/code/session_01D7ZMrHmz1hR963pLbAcJ9e