### PR TITLE
Fix dead link to Energinet opengeh-edi repo (now private)

### DIFF
--- a/docs/datahub3-ddq-business-processes.md
+++ b/docs/datahub3-ddq-business-processes.md
@@ -599,5 +599,5 @@ Source: CIM EDI Guide page 256
 
 ### GitHub
 
-- [Energinet-DataHub/opengeh-edi](https://github.com/Energinet-DataHub/opengeh-edi) — Open-source EDI implementation
+- [Energinet-DataHub](https://github.com/Energinet-DataHub) — Energinet's open-source DataHub repositories (note: the `opengeh-edi` repo is now private)
 - [Energinet-DataHub/ARCHIVED-geh-post-office](https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office) — Message hub (archived, but documents queue architecture)

--- a/docs/datahub3-implementation-plan.md
+++ b/docs/datahub3-implementation-plan.md
@@ -118,7 +118,7 @@ The simulator is powered by **CIM JSON fixture files** — real-format messages 
 **Where do fixtures come from?**
 
 1. **Energinet documentation** — the CIM EDI Guide (Dok. 15/00718-191) and RSM Guide contain example messages
-2. **Energinet's open source repos** — [opengeh-edi](https://github.com/Energinet-DataHub/opengeh-edi) contains test data
+2. **Energinet's open source repos** — [Energinet-DataHub](https://github.com/Energinet-DataHub) org on GitHub (note: the `opengeh-edi` repo is now private)
 3. **Actor Test captures** — once we have access, capture real messages and anonymize them
 4. **Hand-crafted** — for edge cases not covered by the above
 

--- a/docs/mvp1-implementation-plan.md
+++ b/docs/mvp1-implementation-plan.md
@@ -131,7 +131,7 @@ All fixtures are version-controlled. Values chosen for hand-calculability.
 | `charges-system-tariff.json` | System 0.054, transmission 0.049 DKK/kWh |
 | `spot-prices-january.json` | 744 hours with time-differentiated prices |
 
-Fixtures follow the CIM EDI Guide structure (Dok. 15/00718-191) and are cross-referenced with Energinet's [opengeh-edi](https://github.com/Energinet-DataHub/opengeh-edi) test data.
+Fixtures follow the CIM EDI Guide structure (Dok. 15/00718-191).
 
 ---
 

--- a/scripts/create-mvp1-backlog.sh
+++ b/scripts/create-mvp1-backlog.sh
@@ -281,7 +281,7 @@ Parse CIM JSON messages (RSM-012 / NotifyValidatedMeasureData) into domain objec
 | `rsm012-missing-quantity.json` | One point has quality A02 (missing) | Missing data handling |
 | `charges-tariff-update.json` | Grid tariff rates for grid area 344 | Tariff parsing |
 
-Fixture source: Energinet CIM EDI Guide examples + [opengeh-edi](https://github.com/Energinet-DataHub/opengeh-edi) test data.
+Fixture source: Energinet CIM EDI Guide examples.
 
 ## Dependencies
 


### PR DESCRIPTION
Remove or update references to github.com/Energinet-DataHub/opengeh-edi across 4 files — the repo has been made private by Energinet.

https://claude.ai/code/session_01D7ZMrHmz1hR963pLbAcJ9e